### PR TITLE
Pin express-conditional-middleware to 2.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "auth0-extension-tools": "^1.3.0",
     "cookie-parser": "^1.4.3",
     "express": "^4.12.4",
-    "express-conditional-middleware": "^2.0.0",
+    "express-conditional-middleware": "2.0.0",
     "express-jwt": "^3.1.0",
     "jwks-rsa": "^1.1.1",
     "jwt-decode": "^2.1.0",


### PR DESCRIPTION
- Version `2.1.0` [introduced syntax that is invalid in node@4](https://github.com/elliotttf/express-conditional-middleware/compare/v2.0.0...v2.1.0)