### PR TITLE
Public wt url

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auth0-extension-express-tools",
-  "version": "1.1.7",
+  "version": "1.1.8",
   "description": "A set of tools and utilities to simplify the development of Auth0 Extensions with Express.",
   "main": "src/index.js",
   "dependencies": {


### PR DESCRIPTION
✏️ Changes
These changes are meant to bring consistency to the `PUBLIC_WT_URL` generation.
Currently, extension is generating `PUBLIC_WT_URL` based on original url, which can vary. `WT_URL` is always the same, disregard of how exactly extension was executed.

🔗 References
Slack: https://auth0.slack.com/archives/C9170558S/p1529602215000440

🎯 Testing
✅ This has been tested in a webtask