### PR TITLE
Nonce issue fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## [1.1.9] - Unreleased
+
+### Changes
+
+- Added path for "nonce" and "state" cookies
+- Added cookies cleanup on successful login
+
+
 ## [1.1.4] - 2017-01-05
 
 ### Changes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auth0-extension-express-tools",
-  "version": "1.1.8",
+  "version": "1.1.9",
   "description": "A set of tools and utilities to simplify the development of Auth0 Extensions with Express.",
   "main": "src/index.js",
   "dependencies": {

--- a/src/routes/dashboardAdmins.js
+++ b/src/routes/dashboardAdmins.js
@@ -66,10 +66,11 @@ module.exports = function(options) {
 
   const router = express.Router();
   router.get(urlPrefix + '/login', function(req, res) {
+    const basePath = urlHelpers.getBasePath(req);
     const state = crypto.randomBytes(16).toString('hex');
     const nonce = crypto.randomBytes(16).toString('hex');
-    res.cookie(stateKey, state, { path: urlHelpers.getBasePath(req) });
-    res.cookie(nonceKey, nonce, { path: urlHelpers.getBasePath(req) });
+    res.cookie(stateKey, state, { path: basePath });
+    res.cookie(nonceKey, nonce, { path: basePath });
 
     const sessionManager = new tools.SessionManager(options.rta, options.domain, options.baseUrl);
     const redirectTo = sessionManager.createAuthorizeUrl({
@@ -103,6 +104,7 @@ module.exports = function(options) {
       return next(new tools.ValidationError('Login failed. State mismatch.'));
     }
 
+    const basePath = urlHelpers.getBasePath(req);
     const sessionManager = new tools.SessionManager(options.rta, options.domain, options.baseUrl);
     const session = sessionManager.create(req.body.id_token, req.body.access_token, {
       secret: options.secret,
@@ -113,8 +115,8 @@ module.exports = function(options) {
 
     return session
       .then(function(token) {
-        res.clearCookie(stateKey, { path: urlHelpers.getBasePath(req) });
-        res.clearCookie(nonceKey, { path: urlHelpers.getBasePath(req) });
+        res.clearCookie(stateKey, { path: basePath });
+        res.clearCookie(nonceKey, { path: basePath });
         res.header('Content-Type', 'text/html');
         res.status(200).send('<html>' +
           '<head>' +
@@ -131,9 +133,10 @@ module.exports = function(options) {
   });
 
   router.get(urlPrefix + '/logout', function(req, res) {
+    const basePath = urlHelpers.getBasePath(req);
     const encodedBaseUrl = encodeURIComponent(urlHelpers.getBaseUrl(req));
-    res.clearCookie(stateKey, { path: urlHelpers.getBasePath(req) });
-    res.clearCookie(nonceKey, { path: urlHelpers.getBasePath(req) });
+    res.clearCookie(stateKey, { path: basePath });
+    res.clearCookie(nonceKey, { path: basePath });
     res.header('Content-Type', 'text/html');
     res.status(200).send(
       '<html>' +

--- a/tests/routes/dashboardAdmins.js
+++ b/tests/routes/dashboardAdmins.js
@@ -158,8 +158,9 @@ tape('dashboardAdmins should redirect to auth0 on /login', function(t) {
     };
 
   const res = {
-    cookie: function(key, value) {
+    cookie: function(key, value, options) {
       cookies[key] = value;
+      t.equal(options.path, '/login/');
     },
     redirect: function(url) {
       const expectedUrl = 'https://auth0.auth0.com/authorize?client_id=http%3A%2F%2Fapi&response_type=token' +
@@ -299,6 +300,10 @@ tape('dashboardAdmins should return 200 if everything is ok', function(t) {
 
   const res = {
     header: function() { },
+    clearCookie: function(name) {
+      if (name === 'nonce') t.equal(name, 'nonce');
+      else t.equal(name, 'state');
+    },
     status: function(status) {
       return {
         send: function(html) {


### PR DESCRIPTION
## ✏️ Changes
  Express tools was creating cookies (nonce/state) with default path `/`, which, in some cases, could lead to "nonce mismatch" error. In these changes i added path for those cookies and also cleaning-up cookies on login.
  
## 🔗 References
  ZenDesk: https://auth0.zendesk.com/agent/tickets/49221
  
## 🎯 Testing
✅ This change has been tested in a Webtask
✅ This change has unit test coverage
🚫 This change has integration test coverage
🚫 This change has been tested for performance
  
## 🚀 Deployment
✅ This can be deployed any time
  and we'll need to update all the extensions after publishing new version of these tools.