### PR TITLE
DXEX-508 adding headers to managementApi options

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A set of tools and utilities to simplify the development of Auth0 Extensions with Express.",
   "main": "src/index.js",
   "dependencies": {
-    "auth0-extension-tools": "^1.4.5",
+    "auth0-extension-tools": "^1.5.0",
     "cookie-parser": "^1.4.3",
     "express": "^4.17.1",
     "express-conditional-middleware": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auth0-extension-express-tools",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "description": "A set of tools and utilities to simplify the development of Auth0 Extensions with Express.",
   "main": "src/index.js",
   "dependencies": {

--- a/src/middlewares/managementApiClient.js
+++ b/src/middlewares/managementApiClient.js
@@ -6,7 +6,8 @@ module.exports = function(handlerOptions) {
     const isAdministrator = req.user && req.user.access_token && req.user.access_token.length;
     const options = !isAdministrator ? handlerOptions : {
       domain: handlerOptions.domain,
-      accessToken: req.user.access_token
+      accessToken: req.user.access_token,
+      headers: handlerOptions.headers
     };
 
     tools.managementApi.getClient(options)

--- a/tests/middlewares/managementApiClient.js
+++ b/tests/middlewares/managementApiClient.js
@@ -38,3 +38,23 @@ tape('managementApiClient errors should bubble up in the middleware', function(t
     t.end();
   });
 });
+
+tape('managementApiClient should attach client to the request with headers', function(t) {
+  const options = {
+    domain: 'me.auth0.com',
+    accessToken: 'ey',
+    headers: { customHeader: 'custom' }
+  };
+
+  const mw = managementApiClientMiddleware(options);
+  t.ok(mw);
+
+  const req = { };
+  mw(req, { }, function() {
+    t.ok(req);
+    t.ok(req.auth0);
+    const keys = Object.keys(req.auth0);
+    keys.forEach(key => req.auth0[key].resource && t.equal(req.auth0[key].resource.restClient.options.headers.customHeader, 'custom'));
+    t.end();
+  });
+});

--- a/tests/routes/dashboardAdmins.js
+++ b/tests/routes/dashboardAdmins.js
@@ -397,7 +397,8 @@ tape('dashboardAdmins should return 200 if everything is ok', function(t) {
     azp: 'https://test.auth0.com/api/v2/',
     name: 'John Doe',
     admin: true,
-    nonce: 'nonce'
+    nonce: 'nonce',
+    exp: new Date().getTime()
   });
 
   const req = {
@@ -455,7 +456,8 @@ tape('dashboardAdmins should return 200 with legacy nonce and state', function(t
     azp: 'https://test.auth0.com/api/v2/',
     name: 'John Doe',
     admin: true,
-    nonce: 'nonce'
+    nonce: 'nonce',
+    exp: new Date().getTime()
   });
 
   const req = {
@@ -514,7 +516,8 @@ tape('dashboardAdmins should work with localStorage', function(t) {
     azp: 'https://test.auth0.com/api/v2/',
     name: 'John Doe',
     admin: true,
-    nonce: 'nonce'
+    nonce: 'nonce',
+    exp: new Date().getTime()
   });
 
   const req = {


### PR DESCRIPTION
## ✏️ Changes
  
In order to determine how often and which versions of our deploy extensions are being used, we need a way for them to report themselves when communicating with the API.
ManagementClient header was not configurable before this change.
This change is for adding custom headers to managementApi client options.
 
## 🔗 References

https://auth0team.atlassian.net/browse/DXEX-508  

## 🎯 Testing
   
✅ This has been tested locally
✅ This change has unit test coverage